### PR TITLE
fix/68-create-private-key-with-right-permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,8 @@ composer-install: ## Installs composer dependencies
 prepare: ## Runs backend commands
 	$(MAKE) composer-install
 
-generate-private-key:
-	./make.sh generate-private-key
-
-generate-public-key:
-	./make.sh generate-public-key
+generate-oauth-keys: ## Generate oauth private and public keys
+	./make.sh generate-oauth-keys
 
 .PHONY: run tests
 tests: ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ prepare: ## Runs backend commands
 generate-private-key:
 	./make.sh generate-private-key
 
+generate-public-key:
+	./make.sh generate-public-key
+
 .PHONY: run tests
 tests: ## Run tests
 	./make.sh tests ${DOCKER_BE}

--- a/make.sh
+++ b/make.sh
@@ -43,6 +43,7 @@ case ${COMMAND} in
     ;;
   generate-private-key)
     openssl genrsa -out private.key 2048
+    chmod 644 private.key
     ;;
   *)
     echo "Command ${COMMAND} not implemented"

--- a/make.sh
+++ b/make.sh
@@ -3,7 +3,7 @@ set -e
 export U_ID=$(id -u)
 COMMAND=$1
 DOCKER_BE=$2
-OAUTH_KEYS_DIR="$(dirname "$(readlink -f "$0")")"/var/oauth
+OAUTH_KEYS_DIR="$(dirname "$(readlink -f "$0")")"/oauth/var/oauth
 
 case ${COMMAND} in
   ssh-be)

--- a/make.sh
+++ b/make.sh
@@ -45,6 +45,9 @@ case ${COMMAND} in
     openssl genrsa -out private.key 2048
     chmod 644 private.key
     ;;
+  generate-public-key)
+    openssl rsa -in private.key -pubout -out public.key
+    ;;
   *)
     echo "Command ${COMMAND} not implemented"
     ;;

--- a/make.sh
+++ b/make.sh
@@ -3,6 +3,7 @@ set -e
 export U_ID=$(id -u)
 COMMAND=$1
 DOCKER_BE=$2
+OAUTH_KEYS_DIR="$(dirname "$(readlink -f "$0")")"/var/oauth
 
 case ${COMMAND} in
   ssh-be)
@@ -41,12 +42,13 @@ case ${COMMAND} in
   tests)
 	  U_ID=${UID} docker exec --user ${UID} ${DOCKER_BE} vendor/bin/simple-phpunit -c phpunit.xml.dist 2> /dev/null || true
     ;;
-  generate-private-key)
+  generate-oauth-keys)
     openssl genrsa -out private.key 2048
     chmod 644 private.key
-    ;;
-  generate-public-key)
     openssl rsa -in private.key -pubout -out public.key
+    mkdir -p "${OAUTH_KEYS_DIR}"
+    mv private.key "${OAUTH_KEYS_DIR}"/private.key
+    mv public.key "${OAUTH_KEYS_DIR}"/public.key
     ;;
   *)
     echo "Command ${COMMAND} not implemented"


### PR DESCRIPTION
- Create private.key file with 644 permissions when execute make generate-private-key